### PR TITLE
Add delay before batteries properties refresh

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+upower (1:0.99.7.1-2) unstable; urgency=medium
+
+  * Update epoch to override Devuan upgrades over Maemo Leste
+
+ -- Arthur D. <spinal.by@gmail.com>  Sat, 08 Dec 2018 12:49:37 +0300
+
+upower (0.99.7.1-2) unstable; urgency=medium
+
+  * Add delay on battery properties refresh
+
+ -- Arthur D. <spinal.by@gmail.com>  Sat, 08 Dec 2018 00:46:15 +0300
+
 upower (0.99.7.1-1) unstable; urgency=medium
 
   [Merlijn Wajer]


### PR DESCRIPTION
- allow UI applications to react to UPower related events faster
- prevent triggering multiple refresh actions in a row  (these
  operations are CPU expensive)