### PR TITLE
up-device-supply: consider supply at 100% as full

### DIFF
--- a/src/linux/up-device-supply.c
+++ b/src/linux/up-device-supply.c
@@ -818,6 +818,11 @@ up_device_supply_refresh_battery (UpDeviceSupply *supply,
 	if (state == UP_DEVICE_STATE_PENDING_CHARGE && percentage == 100.0)
 		state = UP_DEVICE_STATE_FULLY_CHARGED;
 
+	/* Some batteries may not emit status = full even when charging is
+	 * completed. Report fully-charged state when percentage is 100% */
+	if (state == UP_DEVICE_STATE_CHARGING && percentage == 100.0)
+		state = UP_DEVICE_STATE_FULLY_CHARGED;
+
 	/* the battery isn't charging or discharging, it's just
 	 * sitting there half full doing nothing: try to guess a state */
 	if (state == UP_DEVICE_STATE_UNKNOWN && supply->priv->is_power_supply) {


### PR DESCRIPTION
On some fuel gauges, the kernel's POWER_SUPPLY_PROP_CHARGE_FULL state might not be possible or easy to reach. If battery capacity is reported as 100% during charging, consider the supply fully charged.